### PR TITLE
Changed GetPostprocessedLattice to scale a copy of the input lattice so that the scaling matrix isn't applied multiple times

### DIFF
--- a/src/cudadecoder/lattice-postprocessor.cc
+++ b/src/cudadecoder/lattice-postprocessor.cc
@@ -53,12 +53,13 @@ void LatticePostprocessor::ApplyConfig() {
 }
 
 bool LatticePostprocessor::GetPostprocessedLattice(
-    CompactLattice &clat, CompactLattice *out_clat) const {
+    const CompactLattice &clat_const, CompactLattice *out_clat) const {
   // Nothing to do for empty lattice
   if (clat.NumStates() == 0) return true;
 
   bool ok = true;
   // Scale lattice
+  CompactLattice clat = clat_const;
   if (use_lattice_scale_) fst::ScaleLattice(lattice_scales_, &clat);
 
   // Word insertion penalty

--- a/src/cudadecoder/lattice-postprocessor.h
+++ b/src/cudadecoder/lattice-postprocessor.h
@@ -90,7 +90,7 @@ class LatticePostprocessor {
   LatticePostprocessor(const LatticePostprocessorConfig &config);
   void ApplyConfig();
   bool GetCTM(CompactLattice &clat, CTMResult *ctm_result) const;
-  bool GetPostprocessedLattice(CompactLattice &clat,
+  bool GetPostprocessedLattice(const CompactLattice &clat_const,
                                CompactLattice *out_clat) const;
   std::vector<NBestResult> GetNBestList(CompactLattice &clat) const;
 


### PR DESCRIPTION
GetPostprocessedLattice() is being called multiple times on one lattice object which is inflating its lattice weight